### PR TITLE
Some thoughts on Cell BLAST's poor performance here

### DIFF
--- a/Scripts/run_Cell_BLAST.py
+++ b/Scripts/run_Cell_BLAST.py
@@ -46,7 +46,9 @@ def run_Cell_BLAST(DataPath, LabelsPath, CV_RDataPath, OutputDir, GeneOrderPath 
         features = pd.read_csv(GeneOrderPath,header=0,index_col=None, sep=',')
 
     # read the data and labels
-    data_old = cb.data.ExprDataSet.read_table(DataPath,orientation="cg", sep=",", index_col = 0, header = 0)
+    data_old = cb.data.ExprDataSet.read_table(DataPath,orientation="cg", sep=",", index_col = 0, header = 0, sparsify=True).normalize()
+    # Normalization should precede gene selection, also adding `sparsify=True` to reduce memory usage
+
     labels = pd.read_csv(LabelsPath, header=0,index_col=None, sep=',', usecols = col)
     
     data = cb.data.ExprDataSet(data_old.exprs[tokeep],data_old.obs.iloc[tokeep],data_old.var,data_old.uns)
@@ -79,7 +81,7 @@ def run_Cell_BLAST(DataPath, LabelsPath, CV_RDataPath, OutputDir, GeneOrderPath 
         train.obs['cell_type'] = y_train
                 
         start = tm.time()
-        train = train.normalize()
+        # train = train.normalize()  # No normalization after gene selection
                 
         # reduce dimensions
         num_epoch = 50


### PR DESCRIPTION
Hi there, this is Zhijie Cao, a developer of Cell BLAST. I was surprised to see that Cell BLAST worked so badly in your recent benchmarking work, especially when most of the datasets being used here are also used by us during development, so I checked some details and ran part of your code to see what's going on. Following is my thoughts on why Cell BLAST didn't work here:

(1) Cell BLAST does not work well with the whole transcriptome (all gene features) as input. This is a known issue and probably the main reason you are seeing slow speed and excessive memory usage. We always use gene selection in benchmarking experiments of our own manuscript, which leads to much more reasonable results. The reason is that Cell BLAST actually relies on an unsupervised generative model, which is more difficult to train than supervised ones, given a vast number of irrelevant and noisy genes.

(2) That said, Cell BLAST is supposed to work well with some gene selection, and I expect the performance to decrease with high gene number. However, if I'm correctly interpreting Fig.4 in your manuscript, performance of Cell BLAST increases with gene number, which doesn't make sense to me. After checking the benchmarking code, I found an error in the data preprocessing steps. Specifically, the data is normalized after gene selection, rather than the other way around. This drastically skews the data distribution. The fewer genes selected, the more serious it gets. The order of gene selection after normalization is what we have been using for benchmarks and tutorials. After correcting the order, I can obtain much more reasonable F1 scores using your pipeline (MedF1 = 0.974 with 1000 genes, MedF1 = 0.982 with 5000 genes on the TM dataset). I've included the correction in this pull request (with an additional "sparsify" option in the data reading function that drastically decreases the memory usage). Let me know if you can confirm my observation with the correction.

If you run Cell BLAST on other benchmark datasets with gene selection, you will see also much more reasonable accuracy, speed and memory usage.